### PR TITLE
Fix mysql.dockerfile: use microdnf instead of apt

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,68 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+ACRIS Downloader: fetches NYC real estate property transaction data (ACRIS) from the NYC Department of Finance open data portal and loads it into MySQL, PostgreSQL, or SQLite. The `analysis/` subfolder contains Python tools for post-processing the loaded data.
+
+## Common Commands
+
+### Data Download & Database Loading (via Makefile)
+
+```bash
+make download                  # Download real property basic CSVs
+make mysql                     # Load real property basics into MySQL
+make mysql_real_complete        # + references and remarks
+make mysql_personal             # Load personal property basics
+make mysql_personal_complete    # + personal references and remarks
+make mysql_test                 # Run test query against MySQL
+make psql                       # PostgreSQL equivalent
+make sqlite                     # SQLite equivalent
+make clean                      # Remove downloaded CSVs
+make clean-docker               # Remove Docker volume data
+```
+
+### Docker
+
+```bash
+# MySQL stack (db + loader + adminer on :8080)
+docker compose -f docker-compose.mysql.yml up -d
+# PostgreSQL stack
+docker compose -f docker-compose.psql.yml up -d
+# Note: MySQL port is randomly mapped (check `docker ps` for current port)
+```
+
+Docker MySQL defaults: user=`root`, password=`pass`, database=`acris`.
+
+### Analysis Python Scripts
+
+```bash
+cd analysis
+.venv/bin/python normalize_addresses.py   # Rebuild normalized_addresses table
+```
+
+Python venv at `analysis/.venv/` (Python 3.12, deps: mysql-connector-python, pandas). DB connection config in `analysis/config.py` — port must match current Docker mapping.
+
+## Architecture
+
+**Makefile-driven pipeline**: Download CSVs from NYC SODA API -> create schema -> LOAD DATA LOCAL INFILE -> add indexes. The Makefile handles all three database backends with parallel target naming (`mysql_*`, `psql_*`, `sqlite_*`).
+
+**Docker Compose**: Each backend has its own compose file. The loader container (`acris-mysql`/`acris-psql`) runs `make` as its entrypoint, using the `ACRIS_DATASET` env var to select which target. Data is bind-mounted from `./data`.
+
+**Database tables**: Five real property tables (`real_property_legals`, `real_property_master`, `real_property_parties`, `real_property_references`, `real_property_remarks`), five personal property tables with the same structure, and four reference/lookup tables. All linked by `documentid`. Schemas in `schema/`.
+
+**Borough codes**: 1=Manhattan, 2=Bronx, 3=Brooklyn, 4=Queens, 5=Staten Island.
+
+**Analysis module** (`analysis/`): Python scripts that connect to the running MySQL container to post-process data. Currently includes address normalization that groups raw addresses by BBL (Borough-Block-Lot) and produces the `normalized_addresses` table. See `analysis/NORMALIZED_ADDRESSES.md` for details.
+
+## Key Makefile Variables
+
+- `MYSQL_DATABASE` — defaults to `$(USER)`, overridden to `acris` in docker-compose
+- `MYSQLFLAGS` / `PSQLFLAGS` — extra CLI flags passed to mysql/psql clients
+- `PGSCHEMA` — PostgreSQL schema name, defaults to `acris`
+- `ACRIS_DATASET` — controls which make target the Docker loader runs
+
+## CI
+
+GitHub Actions workflow at `.github/workflows/docker-test.yml` builds and tests both MySQL and PostgreSQL Docker images on push using sample data from `tests/data/`.

--- a/analysis/.gitignore
+++ b/analysis/.gitignore
@@ -1,0 +1,10 @@
+# Virtual environment
+.venv/
+
+# Python
+__pycache__/
+*.py[cod]
+*.egg-info/
+
+# Data outputs
+*.csv

--- a/analysis/CONDO_UNITS.md
+++ b/analysis/CONDO_UNITS.md
@@ -1,0 +1,144 @@
+# condo_units Table
+
+## Overview
+
+The `condo_units` table is a comprehensive inventory of all known condominium units in the ACRIS dataset. It combines data from **all document types** — MAPS filings, condo declarations, deed sales, mortgages, and more — to produce a single row per unit identified by its BBL (Borough-Block-Lot).
+
+**Row count:** 271,610 units across 6,741 buildings.
+
+| Borough | Units |
+|---------|-------|
+| Manhattan | 127,772 |
+| Bronx | 17,116 |
+| Brooklyn | 72,248 |
+| Queens | 46,418 |
+| Staten Island | 8,056 |
+
+## Schema
+
+```sql
+CREATE TABLE condo_units (
+    id            INT AUTO_INCREMENT PRIMARY KEY,
+    borough       TINYINT NOT NULL,        -- 1=Manhattan, 2=Bronx, 3=Brooklyn, 4=Queens, 5=Staten Island
+    block         INT NOT NULL,
+    lot           INT NOT NULL,
+    streetnumber  VARCHAR(20) NOT NULL,     -- normalized
+    streetname    VARCHAR(100) NOT NULL,    -- normalized (see normalize_addresses.py)
+    unit          VARCHAR(20) NOT NULL,     -- most common unit designation for this lot
+    propertytype  CHAR(2) NOT NULL,         -- SC=single condo, MC=multiple condo
+    in_maps       TINYINT(1) NOT NULL,      -- 1 if unit appears in a MAPS filing
+    in_cdec       TINYINT(1) NOT NULL,      -- 1 if unit appears in a CDEC filing
+    in_deed       TINYINT(1) NOT NULL,      -- 1 if unit appears in a DEED
+    in_other      TINYINT(1) NOT NULL,      -- 1 if unit appears in other doc types
+    doc_type_list VARCHAR(200) NOT NULL,    -- semicolon-separated list of all doc types seen
+    total_docs    INT NOT NULL,             -- count of distinct documents referencing this unit
+    earliest_date VARCHAR(10) NOT NULL,     -- earliest doc date (MM/DD/YYYY)
+    latest_date   VARCHAR(10) NOT NULL,     -- latest doc date (MM/DD/YYYY)
+
+    UNIQUE KEY bbl (borough, block, lot),
+    INDEX idx_address (streetname, streetnumber),
+    INDEX idx_address_unit (streetname, streetnumber, unit),
+    INDEX idx_block (borough, block),
+    INDEX idx_sources (in_maps, in_cdec, in_deed)
+);
+```
+
+## How units are identified
+
+Each condo unit in NYC has its own tax lot (BBL). A building at a single address shares a `block` number, and each unit gets a unique `lot` within that block. For example, 514 West 110th Street (block 1881) has lots 1301-1399 for individual units.
+
+Units are included if they appear in `real_property_legals` with `propertytype` of `SC` (Single Residential Condo Unit) or `MC` (Multiple Residential Condo Units) in **any** document type.
+
+## Data sources and coverage
+
+| Source | Units covered | What it captures |
+|--------|-------------|------------------|
+| MAPS (condo map filings) | 157,622 | Official unit registration with the city |
+| CDEC (condo declarations) | 135,011 | Legal establishment of the condominium |
+| DEED (sales) | 209,229 | Units that have been sold at least once |
+| Other (MTGE, SAT, AGMT, etc.) | 262,653 | Mortgages, satisfactions, agreements, etc. |
+| **Combined (this table)** | **271,610** | **All sources merged** |
+
+No single source is complete:
+- **22,784 units** have MAPS but no DEED — registered but never sold (sponsor-held or unsold)
+- **73,924 units** have DEEDs but no MAPS/CDEC — older condos predating the filing system
+- **113,338 units** have no MAPS or CDEC at all — known only through transaction records
+
+## Key document types for condos
+
+- **MAPS** — Condo map/floor plan. Filed when a building becomes a condo. Lists every unit as a separate parcel. Most authoritative for unit enumeration.
+- **CDEC** — Condo declaration. The legal document creating the condominium. Always paired with a MAPS filing (consecutive doc IDs).
+- **DEED** — Sale/transfer of a unit.
+- **MTGE** / **SAT** — Mortgage and satisfaction of mortgage.
+- **AGMT** — Agreement (various legal agreements referencing units).
+- **ASST** — Assignment of lease or mortgage.
+
+## Note on coops
+
+Coops are **not** included in this table. Coop units are shares in a corporation, not individual tax lots, so they don't get MAPS/CDEC filings. Coop units can be found via `propertytype` values `SP` (single coop) and `MP` (multiple coop) in transaction records, but there is no authoritative registry of all units in a coop building.
+
+## Sample queries
+
+### Look up all units in a building
+```sql
+SELECT unit, lot, in_maps, in_deed, total_docs, earliest_date, latest_date
+FROM condo_units
+WHERE streetnumber = '514' AND streetname = 'WEST 110TH STREET' AND borough = 1
+ORDER BY unit;
+```
+
+### Find buildings with the most units
+```sql
+SELECT streetnumber, streetname, borough, block, COUNT(*) AS units
+FROM condo_units
+GROUP BY streetnumber, streetname, borough, block
+ORDER BY units DESC
+LIMIT 20;
+```
+
+### Find units registered but never sold
+```sql
+SELECT streetnumber, streetname, unit, borough
+FROM condo_units
+WHERE in_maps = 1 AND in_deed = 0
+ORDER BY streetname, streetnumber, unit;
+```
+
+### Find units sold but with no condo filing on record
+```sql
+SELECT streetnumber, streetname, unit, borough, earliest_date
+FROM condo_units
+WHERE in_maps = 0 AND in_cdec = 0 AND in_deed = 1
+ORDER BY streetname, streetnumber;
+```
+
+### Count units per building in Manhattan
+```sql
+SELECT streetnumber, streetname, block, COUNT(*) AS units,
+       SUM(in_maps) AS mapped, SUM(in_deed) AS sold
+FROM condo_units
+WHERE borough = 1
+GROUP BY streetnumber, streetname, block
+ORDER BY units DESC;
+```
+
+### Cross-reference with normalized_addresses
+```sql
+SELECT na.streetnumber, na.streetname, na.unit_count AS total_known_units,
+       COUNT(cu.id) AS condo_units
+FROM normalized_addresses na
+JOIN condo_units cu ON na.borough = cu.borough AND na.block = cu.block
+WHERE na.borough = 1
+GROUP BY na.streetnumber, na.streetname, na.unit_count, na.block
+ORDER BY condo_units DESC
+LIMIT 20;
+```
+
+## Regenerating the table
+
+```bash
+cd analysis
+.venv/bin/python build_condo_units.py
+```
+
+Drops and recreates the table. Requires the MySQL container and the `normalize_addresses` module (imported for street name normalization).

--- a/analysis/DATA_DISCOVERIES.md
+++ b/analysis/DATA_DISCOVERIES.md
@@ -1,0 +1,144 @@
+# ACRIS Data Discoveries
+
+Findings from exploring the ACRIS dataset. These inform how to query the data correctly and what pitfalls to avoid.
+
+## Known data quality issues
+
+### Boolean columns are broken (all zeros)
+
+The CSV contains `Y`/`N` for boolean fields (`easement`, `airrights`, `subterraneanrights` in `real_property_legals`; `not_used_1`, `not_used_2` in `real_property_references`). MySQL's `LOAD DATA LOCAL INFILE` cannot parse `Y`/`N` into `boolean` (`tinyint(1)`) and silently inserts `0` for all values. **All 22.5M rows read as 0 regardless of the original value.**
+
+Fix: change these columns to `CHAR(1)` or `VARCHAR(1)` in the schema.
+
+### Missing schema definitions
+
+The schema files (`schema/mysql.sql`, `schema/postgres.sql`, `schema/sqlite.sql`) do not define tables for:
+- `real_property_remarks`
+- `personal_property_legals`, `personal_property_master`, `personal_property_parties`
+- `personal_property_references`, `personal_property_remarks`
+
+The Makefile has targets to load these (`mysql_personal`, `mysql_real_complete`) but they will fail because the tables don't exist.
+
+### goodthroughdate type inconsistency
+
+In `real_property_references`, `goodthroughdate` is declared as `timestamp` while all other tables use `text`. The CSV format is `MM/DD/YYYY HH:MM:SS AM` which MySQL can't parse as a timestamp (expects `YYYY-MM-DD HH:MM:SS`). Values will be null or fail on import.
+
+### documentid type mismatch in SQLite schema
+
+SQLite schema uses `bigint` for `documentid`. Document IDs are zero-padded strings (e.g., `2005011101969002`) and should be `varchar`/`text` to preserve leading zeros.
+
+### All dates stored as text
+
+`docdate`, `recordedfiled`, `modifieddate`, `goodthroughdate` are all `text` in `MM/DD/YYYY` format. This prevents native date comparisons and range queries. Sorting by date requires parsing.
+
+## Street name variations
+
+A single address can appear with 10+ different spellings in `real_property_legals`. Examples for 420 East 72nd Street:
+
+- `EAST 72ND STREET`, `EAST 72 STREET`, `EAST 72ND ST`, `E 72ND STREET`, `E. 72ND STREET`, `EAST 72ND   STREET` (double space), `EAST 72ND ST.`
+
+The `normalized_addresses` table resolves this by grouping on BBL (borough+block+lot) — the authoritative property identifier — and picking the most common normalized spelling. See [NORMALIZED_ADDRESSES.md](NORMALIZED_ADDRESSES.md).
+
+## Property types relevant to residential analysis
+
+### Townhouse types
+| Code | Description | Notes |
+|------|-------------|-------|
+| D1 | Dwelling only - 1 family | Classic single-family townhouse |
+| D2 | Dwelling only - 2 family | Two-unit brownstone |
+| D3 | Dwelling only - 3 family | Three-unit brownstone |
+| RP | 1-2 family with attached garage/vacant land | Older code, split into RG/RV |
+| RG | 1-2 family with attached garage | Rare in Manhattan |
+| RV | 1-2 family with vacant land | Very rare in Manhattan |
+
+### Condo types
+| Code | Description | Notes |
+|------|-------------|-------|
+| SC | Single residential condo unit | Each unit is a separate tax lot |
+| MC | Multiple residential condo units | Multiple units in one transaction |
+| CC | Commercial condo unit(s) | Commercial space within condo buildings |
+| PS | Parking space | Condo parking units |
+| SR | Storage room | Condo storage units |
+| CK | Condo unit without kitchen | Studios, maids rooms registered as units |
+| BS | Bulk sale of condominiums | Sponsor selling multiple units at once |
+
+### Coop types
+| Code | Description | Notes |
+|------|-------------|-------|
+| SP | Single residential coop unit | No individual tax lot, shares in a corp |
+| MP | Multiple residential coop units | Multiple coop units in one transaction |
+| CP | Commercial coop unit(s) | Commercial space in coop buildings |
+
+## Condo vs coop: structural differences in ACRIS
+
+**Condos** have individual BBLs per unit. The city maintains a formal registry via MAPS and CDEC filings. Each unit can be independently looked up, mortgaged, and transferred.
+
+**Coops** are a single BBL for the entire building. Shareholders own stock in a corporation, not real property. There are essentially no MAPS filings for coops (only 115 out of 271K+ coop-related records). Unit enumeration for coops must rely on transaction records (DEEDs, mortgages, etc.) and is inherently incomplete.
+
+## Key document types
+
+### For identifying properties
+- **MAPS** — Condo floor plan. Lists every unit as a parcel. Best source for complete unit enumeration in condo buildings.
+- **CDEC** — Condo declaration. Legal creation of the condominium. Always paired with MAPS (consecutive doc IDs, same filing date).
+
+### For tracking sales
+- **DEED** — Transfer of ownership. Filter with `docamount > 0` for actual sales (vs trust transfers at $0).
+- **RPTT** — NYC Real Property Transfer Tax. Confirms a sale occurred.
+
+### Other common types
+- **MTGE** — Mortgage. Indicates financing activity.
+- **SAT** — Satisfaction of mortgage. Mortgage paid off.
+- **AGMT** — Agreement. Various legal agreements.
+- **ASST** — Assignment of lease or mortgage.
+- **PAT** — Power of attorney.
+- **LOCC** — Lien of common charges. Indicates unpaid condo fees.
+
+## Condo unit coverage analysis
+
+No single document type captures all condo units:
+
+| Source | Units | % of total |
+|--------|-------|-----------|
+| MAPS | 157,622 | 58% |
+| CDEC | 135,011 | 50% |
+| DEED | 209,229 | 77% |
+| All sources combined | 271,610 | 100% |
+
+- 22,784 units in MAPS but never sold — sponsor-held or unsold
+- 73,924 units sold (DEED) but no MAPS/CDEC on file — older buildings
+- 113,338 units with no MAPS or CDEC — known only from transactions
+
+See [CONDO_UNITS.md](CONDO_UNITS.md) for the comprehensive inventory table.
+
+## Multiple MAPS filings per building
+
+Most condo buildings have 1-2 MAPS filings, but some have many more (up to 61). Multiple filings occur due to:
+- Amendments adding new units (subdivisions, conversions of common space)
+- Corrections to the original filing
+- Phased construction
+
+When building a unit inventory, take the **union across all MAPS filings** for a given block.
+
+## Manhattan townhouse sales
+
+~4,600 unique townhouse addresses identified from deed sales in Manhattan (borough=1), filtered by property types D1, D2, D3, RP, RG, RV. Annual volume:
+- Typical year: 150-280 sales
+- COVID dip (2020): ~150 sales
+- Peak years: 2004-2007, 2021-2022
+- D1 (1-family) consistently most traded
+
+Exported to `data/manhattan_townhouses.csv`.
+
+## Added indexes
+
+Beyond the default `documentid` indexes created by the Makefile, these were added for analysis queries:
+
+**real_property_legals:**
+- `idx_address (streetname, streetnumber)` — address search
+- `idx_address_unit (streetname, streetnumber, unit)` — address + unit search
+- `idx_bbl (borough, block, lot)` — BBL lookups
+
+**real_property_master:**
+- `idx_doctype (doctype)` — filter by document type
+
+Note: these indexes are not persisted across `make mysql` runs. They would need to be added to the Makefile or a post-load script.

--- a/analysis/NORMALIZED_ADDRESSES.md
+++ b/analysis/NORMALIZED_ADDRESSES.md
@@ -1,0 +1,128 @@
+# normalized_addresses Table
+
+## Overview
+
+The `normalized_addresses` table provides a deduplicated, normalized view of all property addresses in the ACRIS dataset. It is derived from `real_property_legals` by grouping records on the NYC BBL (Borough-Block-Lot) identifier and resolving the most common spelling of each address.
+
+**Row count:** ~1.13M properties across all five boroughs.
+
+| Borough | Code | Properties |
+|---------|------|-----------|
+| Manhattan | 1 | 182,652 |
+| Bronx | 2 | 108,473 |
+| Brooklyn | 3 | 362,914 |
+| Queens | 4 | 377,644 |
+| Staten Island | 5 | 99,989 |
+
+## Schema
+
+```sql
+CREATE TABLE normalized_addresses (
+    id            INT AUTO_INCREMENT PRIMARY KEY,
+    borough       TINYINT NOT NULL,       -- 1=Manhattan, 2=Bronx, 3=Brooklyn, 4=Queens, 5=Staten Island
+    block         INT NOT NULL,
+    lot           INT NOT NULL,
+    streetnumber  VARCHAR(20) NOT NULL,    -- e.g. '420', '88-37'
+    streetname    VARCHAR(100) NOT NULL,   -- normalized, e.g. 'EAST 72ND STREET'
+    unit_count    INT NOT NULL DEFAULT 0,  -- number of distinct units found in transaction history
+    units         TEXT,                    -- semicolon-separated list of unit identifiers
+
+    UNIQUE KEY bbl (borough, block, lot),
+    INDEX idx_street (streetname, streetnumber),
+    INDEX idx_street_full (streetnumber, streetname, borough)
+);
+```
+
+## Normalization rules applied
+
+The `streetname` column has been cleaned from raw ACRIS data using these rules:
+
+- **Direction prefixes** expanded: `E`, `E.` -> `EAST`; `W`, `W.` -> `WEST`; etc.
+- **Street type suffixes** expanded: `ST` -> `STREET`, `AVE` -> `AVENUE`, `PL` -> `PLACE`, `BLVD` -> `BOULEVARD`, `DR` -> `DRIVE`, `CT` -> `COURT`, `RD` -> `ROAD`, etc.
+- **Ordinal suffixes** corrected: `72 STREET` -> `72ND STREET`, `72TH` -> `72ND`, `3ST` -> `3RD`
+- **Spelled-out numbers** converted: `FIFTH` -> `5TH`, `THIRD` -> `3RD`
+- **Common typos** fixed: `STRET` -> `STREET`, `AVENIE` -> `AVENUE`, `BRADHURTS` -> `BRADHURST`, etc.
+- **Embedded unit info** stripped: `EAST 72ND STREET APT 3B` -> `EAST 72ND STREET`
+- **Whitespace** collapsed and trailing punctuation removed
+
+When multiple spellings exist for the same BBL, the most frequently occurring normalized form is chosen.
+
+## Indexes
+
+| Index | Columns | Use case |
+|-------|---------|----------|
+| `bbl` (unique) | borough, block, lot | Look up a specific property by its BBL |
+| `idx_street` | streetname, streetnumber | Find all properties on a street, optionally filtered by number |
+| `idx_street_full` | streetnumber, streetname, borough | Find a specific address in a specific borough |
+
+## Sample queries
+
+### Look up a specific address
+```sql
+SELECT * FROM normalized_addresses
+WHERE streetnumber = '420' AND streetname = 'EAST 72ND STREET' AND borough = 1;
+```
+
+### Find all properties on a street
+```sql
+SELECT streetnumber, streetname, unit_count
+FROM normalized_addresses
+WHERE streetname = 'EAST 72ND STREET' AND borough = 1
+ORDER BY CAST(streetnumber AS UNSIGNED);
+```
+
+### Find large buildings (by unit count)
+```sql
+SELECT streetnumber, streetname, borough, unit_count
+FROM normalized_addresses
+WHERE borough = 1
+ORDER BY unit_count DESC
+LIMIT 20;
+```
+
+### Find all townhouse-type properties (join with sales data)
+```sql
+SELECT na.streetnumber, na.streetname, na.block, na.lot,
+       l.propertytype, p.typedescription
+FROM normalized_addresses na
+JOIN real_property_legals l ON na.borough = l.borough
+    AND na.block = l.block AND na.lot = l.lot
+LEFT JOIN property_type_codes p ON l.propertytype = p.propertytype
+WHERE na.borough = 1
+  AND l.propertytype IN ('D1','D2','D3')
+GROUP BY na.streetnumber, na.streetname, na.block, na.lot,
+         l.propertytype, p.typedescription
+ORDER BY na.streetname, na.streetnumber;
+```
+
+### Find sales history for a specific address
+```sql
+SELECT m.docdate, m.docamount, m.doctype,
+       p1.name AS seller, p2.name AS buyer
+FROM normalized_addresses na
+JOIN real_property_legals l ON na.borough = l.borough
+    AND na.block = l.block AND na.lot = l.lot
+JOIN real_property_master m ON l.documentid = m.documentid
+LEFT JOIN real_property_parties p1 ON m.documentid = p1.documentid AND p1.partytype = 1
+LEFT JOIN real_property_parties p2 ON m.documentid = p2.documentid AND p2.partytype = 2
+WHERE na.streetnumber = '420' AND na.streetname = 'EAST 72ND STREET' AND na.borough = 1
+  AND m.doctype = 'DEED' AND m.docamount > 0
+ORDER BY m.docdate DESC;
+```
+
+### Search by partial street name
+```sql
+SELECT streetnumber, streetname, borough, unit_count
+FROM normalized_addresses
+WHERE streetname LIKE 'PARK AVENUE%' AND borough = 1
+ORDER BY CAST(streetnumber AS UNSIGNED);
+```
+
+## Regenerating the table
+
+```bash
+cd analysis
+.venv/bin/python normalize_addresses.py
+```
+
+This will drop and recreate the table. Requires the MySQL container to be running. Update `config.py` with the current mapped port if it has changed.

--- a/analysis/build_condo_units.py
+++ b/analysis/build_condo_units.py
@@ -1,0 +1,222 @@
+"""
+Build a comprehensive condo unit inventory from all ACRIS document types.
+
+Combines MAPS, CDEC, DEED, and all other doc types to find every known
+condo unit (SC/MC property types) and produces a single table with
+normalized addresses and source metadata.
+"""
+
+import mysql.connector
+import pandas as pd
+from collections import Counter
+from config import DB_CONFIG
+from normalize_addresses import normalize_streetname
+
+# ---------------------------------------------------------------------------
+# Queries
+# ---------------------------------------------------------------------------
+
+# Pull every legals row that references a condo unit, along with doc metadata
+FETCH_QUERY = """
+    SELECT l.borough, l.block, l.lot,
+           l.streetnumber, l.streetname, l.unit, l.propertytype,
+           m.doctype, m.docdate, m.documentid
+    FROM real_property_legals l
+    JOIN real_property_master m USING (documentid)
+    WHERE l.propertytype IN ('SC', 'MC')
+"""
+
+CREATE_TABLE = """
+    DROP TABLE IF EXISTS condo_units;
+    CREATE TABLE condo_units (
+        id INT AUTO_INCREMENT PRIMARY KEY,
+        borough TINYINT NOT NULL,
+        block INT NOT NULL,
+        lot INT NOT NULL,
+        streetnumber VARCHAR(20) NOT NULL DEFAULT '',
+        streetname VARCHAR(100) NOT NULL DEFAULT '',
+        unit VARCHAR(20) NOT NULL DEFAULT '',
+        propertytype CHAR(2) NOT NULL DEFAULT '',
+        in_maps TINYINT(1) NOT NULL DEFAULT 0,
+        in_cdec TINYINT(1) NOT NULL DEFAULT 0,
+        in_deed TINYINT(1) NOT NULL DEFAULT 0,
+        in_other TINYINT(1) NOT NULL DEFAULT 0,
+        doc_type_list VARCHAR(200) NOT NULL DEFAULT '',
+        total_docs INT NOT NULL DEFAULT 0,
+        earliest_date VARCHAR(10) NOT NULL DEFAULT '',
+        latest_date VARCHAR(10) NOT NULL DEFAULT '',
+        UNIQUE KEY bbl (borough, block, lot),
+        INDEX idx_address (streetname, streetnumber),
+        INDEX idx_address_unit (streetname, streetnumber, unit),
+        INDEX idx_block (borough, block),
+        INDEX idx_sources (in_maps, in_cdec, in_deed)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+"""
+
+INSERT_BATCH = """
+    INSERT INTO condo_units
+        (borough, block, lot, streetnumber, streetname, unit, propertytype,
+         in_maps, in_cdec, in_deed, in_other,
+         doc_type_list, total_docs, earliest_date, latest_date)
+    VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+"""
+
+BATCH_SIZE = 5000
+
+
+def fetch_data():
+    """Fetch all condo unit records from the database."""
+    conn = mysql.connector.connect(**DB_CONFIG)
+    print("Connected to database. Fetching condo records...")
+    df = pd.read_sql(FETCH_QUERY, conn)
+    conn.close()
+    print(f"Fetched {len(df):,} records.")
+    return df
+
+
+def build_unit_inventory(df: pd.DataFrame) -> pd.DataFrame:
+    """Aggregate records into one row per unique BBL (condo unit)."""
+    print("Normalizing street names...")
+    df["norm_streetname"] = df["streetname"].apply(normalize_streetname)
+
+    print("Building unit inventory...")
+    grouped = df.groupby(["borough", "block", "lot"])
+    results = []
+
+    for (borough, block, lot), group in grouped:
+        # Canonical street name: most common normalized form
+        name_counts = Counter(n for n in group["norm_streetname"] if n)
+        canonical_name = name_counts.most_common(1)[0][0] if name_counts else ""
+
+        # Canonical street number
+        num_counts = Counter(
+            str(n).strip() for n in group["streetnumber"]
+            if pd.notna(n) and str(n).strip()
+        )
+        canonical_number = num_counts.most_common(1)[0][0] if num_counts else ""
+
+        # Unit: most common non-empty unit value
+        unit_counts = Counter(
+            str(u).strip() for u in group["unit"]
+            if pd.notna(u) and str(u).strip()
+        )
+        canonical_unit = unit_counts.most_common(1)[0][0] if unit_counts else ""
+
+        # Property type: prefer SC over MC
+        ptypes = set(group["propertytype"].dropna())
+        ptype = "SC" if "SC" in ptypes else ("MC" if "MC" in ptypes else "")
+
+        # Source flags
+        doc_types = set(group["doctype"].dropna())
+        in_maps = 1 if "MAPS" in doc_types else 0
+        in_cdec = 1 if "CDEC" in doc_types else 0
+        in_deed = 1 if "DEED" in doc_types else 0
+        other_types = doc_types - {"MAPS", "CDEC", "DEED"}
+        in_other = 1 if other_types else 0
+
+        # Doc type summary
+        doc_type_list = "; ".join(sorted(doc_types))
+
+        # Total distinct documents
+        total_docs = group["documentid"].nunique()
+
+        # Date range
+        dates = group["docdate"].dropna()
+        dates = dates[dates != ""]
+        earliest = ""
+        latest = ""
+        if len(dates) > 0:
+            # Dates are MM/DD/YYYY, sort lexically won't work — parse minimally
+            def parse_date_sortable(d):
+                try:
+                    parts = str(d).split("/")
+                    return f"{parts[2]}{parts[0].zfill(2)}{parts[1].zfill(2)}"
+                except (IndexError, ValueError):
+                    return ""
+            sortable = dates.apply(parse_date_sortable)
+            sortable = sortable[sortable != ""]
+            if len(sortable) > 0:
+                earliest = dates.iloc[sortable.values.argmin()]
+                latest = dates.iloc[sortable.values.argmax()]
+
+        results.append((
+            int(borough), int(block), int(lot),
+            canonical_number, canonical_name, canonical_unit, ptype,
+            in_maps, in_cdec, in_deed, in_other,
+            doc_type_list[:200], total_docs, earliest, latest,
+        ))
+
+    print(f"Built inventory of {len(results):,} unique condo units.")
+    return results
+
+
+def write_to_db(rows):
+    """Write inventory to the condo_units table."""
+    conn = mysql.connector.connect(**DB_CONFIG)
+    cursor = conn.cursor()
+
+    print("Creating condo_units table...")
+    for stmt in CREATE_TABLE.strip().split(";"):
+        stmt = stmt.strip()
+        if stmt:
+            cursor.execute(stmt)
+    conn.commit()
+
+    print(f"Inserting {len(rows):,} rows...")
+    for i in range(0, len(rows), BATCH_SIZE):
+        batch = rows[i : i + BATCH_SIZE]
+        cursor.executemany(INSERT_BATCH, batch)
+        conn.commit()
+        if (i // BATCH_SIZE) % 20 == 0:
+            print(f"  {i + len(batch):,} / {len(rows):,}")
+
+    print(f"Inserted {len(rows):,} rows.")
+    cursor.close()
+    conn.close()
+
+
+def print_stats(rows):
+    """Print summary statistics."""
+    df = pd.DataFrame(rows, columns=[
+        "borough", "block", "lot", "streetnumber", "streetname", "unit",
+        "propertytype", "in_maps", "in_cdec", "in_deed", "in_other",
+        "doc_type_list", "total_docs", "earliest_date", "latest_date",
+    ])
+
+    borough_names = {1: "Manhattan", 2: "Bronx", 3: "Brooklyn", 4: "Queens", 5: "Staten Island"}
+
+    print(f"\nTotal condo units: {len(df):,}")
+    print(f"\nBy borough:")
+    for borough, count in df.groupby("borough").size().items():
+        print(f"  {borough_names.get(borough, borough)}: {count:,}")
+
+    print(f"\nBy source coverage:")
+    print(f"  In MAPS:  {df['in_maps'].sum():,}")
+    print(f"  In CDEC:  {df['in_cdec'].sum():,}")
+    print(f"  In DEED:  {df['in_deed'].sum():,}")
+    print(f"  In other: {df['in_other'].sum():,}")
+
+    maps_only = len(df[(df["in_maps"] == 1) & (df["in_deed"] == 0)])
+    deed_only = len(df[(df["in_maps"] == 0) & (df["in_cdec"] == 0) & (df["in_deed"] == 1)])
+    no_maps_no_cdec = len(df[(df["in_maps"] == 0) & (df["in_cdec"] == 0)])
+    print(f"\n  MAPS but no DEED:  {maps_only:,} (registered but never sold)")
+    print(f"  DEED only (no MAPS/CDEC): {deed_only:,} (sold but no condo filing on record)")
+    print(f"  No MAPS or CDEC:   {no_maps_no_cdec:,}")
+
+    # Distinct buildings (by borough+block)
+    buildings = df.groupby(["borough", "block"]).size().reset_index(name="units")
+    print(f"\nDistinct buildings (borough+block): {len(buildings):,}")
+    print(f"  Median units per building: {buildings['units'].median():.0f}")
+    print(f"  Mean units per building:   {buildings['units'].mean():.1f}")
+    print(f"  Max units in a building:   {buildings['units'].max()}")
+
+
+def main():
+    df = fetch_data()
+    rows = build_unit_inventory(df)
+    write_to_db(rows)
+    print_stats(rows)
+
+
+if __name__ == "__main__":
+    main()

--- a/analysis/config.py
+++ b/analysis/config.py
@@ -1,0 +1,7 @@
+DB_CONFIG = {
+    "host": "127.0.0.1",
+    "port": 32769,
+    "user": "root",
+    "password": "pass",
+    "database": "acris",
+}

--- a/analysis/normalize_addresses.py
+++ b/analysis/normalize_addresses.py
@@ -1,0 +1,392 @@
+"""
+Address normalizer for ACRIS real property data.
+
+Reads raw addresses from real_property_legals, normalizes street names,
+and produces a canonical address per borough/block/lot with all known units.
+"""
+
+import re
+import mysql.connector
+import pandas as pd
+from collections import Counter
+from config import DB_CONFIG
+
+
+# ---------------------------------------------------------------------------
+# Normalization rules
+# ---------------------------------------------------------------------------
+
+# Direction prefixes: normalize short forms to full words
+DIRECTION_MAP = {
+    "E": "EAST",
+    "E.": "EAST",
+    "W": "WEST",
+    "W.": "WEST",
+    "N": "NORTH",
+    "N.": "NORTH",
+    "S": "SOUTH",
+    "S.": "SOUTH",
+}
+
+# Street type suffixes: normalize abbreviations to full words
+SUFFIX_MAP = {
+    "ST": "STREET",
+    "ST.": "STREET",
+    "ST.,": "STREET",
+    "STREE": "STREET",
+    "STRET": "STREET",
+    "STRRET": "STREET",
+    "AVE": "AVENUE",
+    "AVE.": "AVENUE",
+    "AVENU": "AVENUE",
+    "AVENEU": "AVENUE",
+    "AVENEU": "AVENUE",
+    "AVENIE": "AVENUE",
+    "AVENUW": "AVENUE",
+    "AVEUE": "AVENUE",
+    "AVEBYE": "AVENUE",
+    "AVENNUE": "AVENUE",
+    "PL": "PLACE",
+    "PL.": "PLACE",
+    "BLVD": "BOULEVARD",
+    "BLVD.": "BOULEVARD",
+    "DR": "DRIVE",
+    "DR.": "DRIVE",
+    "CT": "COURT",
+    "CT.": "COURT",
+    "LN": "LANE",
+    "LN.": "LANE",
+    "TER": "TERRACE",
+    "RD": "ROAD",
+    "RD.": "ROAD",
+    "PKWY": "PARKWAY",
+    "SQ": "SQUARE",
+    "SQ.": "SQUARE",
+}
+
+# Ordinal suffixes for street numbers
+ORDINAL_MAP = {
+    "1": "1ST", "2": "2ND", "3": "3RD",
+    "21": "21ST", "22": "22ND", "23": "23RD",
+    "31": "31ST", "32": "32ND", "33": "33RD",
+    "41": "41ST", "42": "42ND", "43": "43RD",
+    "51": "51ST", "52": "52ND", "53": "53RD",
+    "61": "61ST", "62": "62ND", "63": "63RD",
+    "71": "71ST", "72": "72ND", "73": "73RD",
+    "81": "81ST", "82": "82ND", "83": "83RD",
+    "91": "91ST", "92": "92ND", "93": "93RD",
+    "101": "101ST", "102": "102ND", "103": "103RD",
+    "111": "111TH", "112": "112TH", "113": "113TH",
+    "121": "121ST", "122": "122ND", "123": "123RD",
+    "131": "131ST", "132": "132ND", "133": "133RD",
+    "141": "141ST", "142": "142ND", "143": "143RD",
+    "151": "151ST", "152": "152ND", "153": "153RD",
+    "161": "161ST", "162": "162ND", "163": "163RD",
+    "171": "171ST", "172": "172ND", "173": "173RD",
+    "181": "181ST", "182": "182ND", "183": "183RD",
+    "191": "191ST", "192": "192ND", "193": "193RD",
+    "201": "201ST", "202": "202ND", "203": "203RD",
+    "211": "211TH", "212": "212TH", "213": "213TH",
+    "221": "221ST", "222": "222ND", "223": "223RD",
+}
+
+# Words spelled out for numbered streets/avenues
+SPELLED_NUMBERS = {
+    "FIRST": "1ST",
+    "SECOND": "2ND",
+    "THIRD": "3RD",
+    "FOURTH": "4TH",
+    "FIFTH": "5TH",
+    "SIXTH": "6TH",
+    "SEVENTH": "7TH",
+    "EIGHTH": "8TH",
+    "EIGTH": "8TH",
+    "NINTH": "9TH",
+    "TENTH": "10TH",
+    "ELEVENTH": "11TH",
+    "ELEVNTH": "11TH",
+    "TWELFTH": "12TH",
+    "THIRTEENTH": "13TH",
+}
+
+# Known name corrections
+NAME_FIXES = {
+    "AMSTERDM": "AMSTERDAM",
+    "BRADHURTS": "BRADHURST",
+    "COUMBUS": "COLUMBUS",
+    "EDGECUMBE": "EDGECOMBE",
+    "EDGECOMBER": "EDGECOMBE",
+    "MANHATTEN": "MANHATTAN",
+    "MORNINSSIDE": "MORNINGSIDE",
+    "FILTH": "FIFTH",
+    "SEVETH": "SEVENTH",
+    "SEVERTH": "SEVENTH",
+    "THID": "THIRD",
+    "THIED": "THIRD",
+}
+
+
+def normalize_streetname(raw: str) -> str:
+    """Normalize a raw ACRIS street name to a canonical form."""
+    if not raw or not raw.strip():
+        return ""
+
+    name = raw.strip().upper()
+
+    # Strip trailing punctuation: backtick, comma, period (if not part of abbreviation)
+    name = re.sub(r"[`]+$", "", name)
+    name = re.sub(r",\s*$", "", name)
+
+    # Strip appended unit/apt info:
+    # "EAST 72ND STREET UNIT 21J" -> "EAST 72ND STREET"
+    # "W 72ND ST APT 6N" -> "W 72ND ST"
+    # "BROADWAY #27A" -> "BROADWAY"
+    # "7TH AVENUE, 5G" -> "7TH AVENUE"
+    name = re.sub(
+        r"\s*(,\s*|\s)(APT\.?|UNIT|#|SUITE|STE|FL|FLOOR|PENTHOUSE|PH)\s*.*$",
+        "",
+        name,
+    )
+    # Also strip ", <unit>" patterns like "BROADWAY, #12D" or "5TH AVE 22G"
+    name = re.sub(r",\s*#?\w+$", "", name)
+
+    # Collapse multiple spaces
+    name = re.sub(r"\s+", " ", name).strip()
+
+    # Strip trailing periods
+    name = re.sub(r"\.\s*$", "", name)
+
+    # Fix concatenated direction+street: "EAST72ND" -> "EAST 72ND", "WEST72ND" -> "WEST 72ND"
+    name = re.sub(r"^(EAST|WEST|NORTH|SOUTH)(\d)", r"\1 \2", name)
+
+    # Fix concatenated number+suffix: "72ST" -> "72 ST" (only bare number+suffix)
+    name = re.sub(r"^(\d+)(ST|ND|RD|TH)\b", r"\1 \2", name)
+
+    # Split into tokens for processing
+    tokens = name.split()
+    if not tokens:
+        return ""
+
+    result = []
+    i = 0
+
+    # --- Pass 1: Normalize direction prefix ---
+    if tokens[0] in DIRECTION_MAP:
+        result.append(DIRECTION_MAP[tokens[0]])
+        i = 1
+    # Handle "W EST" -> "WEST"
+    elif len(tokens) >= 2 and tokens[0] == "W" and tokens[1] == "EST":
+        result.append("WEST")
+        i = 2
+
+    # --- Pass 2: Process remaining tokens ---
+    while i < len(tokens):
+        token = tokens[i]
+
+        # Fix known misspellings
+        if token in NAME_FIXES:
+            token = NAME_FIXES[token]
+
+        # Convert spelled-out numbers: "FIFTH" -> "5TH"
+        if token in SPELLED_NUMBERS:
+            token = SPELLED_NUMBERS[token]
+
+        # Fix wrong ordinal suffixes: "72TH" -> "72ND"
+        m = re.match(r"^(\d+)(ST|ND|RD|TH)$", token)
+        if m:
+            num = m.group(1)
+            token = _make_ordinal(int(num))
+
+        result.append(token)
+        i += 1
+
+    # --- Pass 3: Normalize suffix (last token) ---
+    if result:
+        last = result[-1]
+        if last in SUFFIX_MAP:
+            result[-1] = SUFFIX_MAP[last]
+
+    # --- Pass 4: Add missing ordinal suffix ---
+    # "EAST 72 STREET" -> "EAST 72ND STREET"
+    # Check if there's a bare number followed by a street type
+    for idx in range(len(result) - 1):
+        if re.match(r"^\d+$", result[idx]) and result[idx + 1] in (
+            "STREET", "AVENUE", "PLACE", "BOULEVARD", "DRIVE", "COURT",
+            "LANE", "TERRACE", "ROAD", "PARKWAY", "SQUARE",
+        ):
+            result[idx] = _make_ordinal(int(result[idx]))
+
+    # Collapse spaces again and return
+    return " ".join(result)
+
+
+def _make_ordinal(n: int) -> str:
+    """Convert an integer to its ordinal string: 1->1ST, 2->2ND, 72->72ND."""
+    s = str(n)
+    if s in ORDINAL_MAP:
+        return ORDINAL_MAP[s]
+    # General rules
+    if 11 <= (n % 100) <= 13:
+        return f"{n}TH"
+    remainder = n % 10
+    if remainder == 1:
+        return f"{n}ST"
+    if remainder == 2:
+        return f"{n}ND"
+    if remainder == 3:
+        return f"{n}RD"
+    return f"{n}TH"
+
+
+# ---------------------------------------------------------------------------
+# Database queries and main logic
+# ---------------------------------------------------------------------------
+
+QUERY = """
+    SELECT borough, block, lot, streetnumber, streetname, unit
+    FROM real_property_legals
+    WHERE borough IS NOT NULL
+      AND block IS NOT NULL AND block > 0
+      AND lot IS NOT NULL AND lot > 0
+"""
+
+
+def fetch_data():
+    """Fetch all address records from the database."""
+    conn = mysql.connector.connect(**DB_CONFIG)
+    print("Connected to database. Fetching records...")
+    df = pd.read_sql(QUERY, conn)
+    conn.close()
+    print(f"Fetched {len(df):,} records.")
+    return df
+
+
+def build_normalized_addresses(df: pd.DataFrame) -> pd.DataFrame:
+    """
+    Group by borough/block/lot, normalize street names,
+    pick the most common canonical name, and collect units.
+    """
+    print("Normalizing street names...")
+    df["normalized_streetname"] = df["streetname"].apply(normalize_streetname)
+
+    print("Grouping by borough/block/lot...")
+    results = []
+    grouped = df.groupby(["borough", "block", "lot"])
+
+    for (borough, block, lot), group in grouped:
+        # Pick the most common normalized street name
+        name_counts = Counter(
+            n for n in group["normalized_streetname"] if n
+        )
+        if name_counts:
+            canonical_name = name_counts.most_common(1)[0][0]
+        else:
+            canonical_name = ""
+
+        # Pick the most common street number
+        num_counts = Counter(
+            str(n).strip() for n in group["streetnumber"] if pd.notna(n) and str(n).strip()
+        )
+        if num_counts:
+            canonical_number = num_counts.most_common(1)[0][0]
+        else:
+            canonical_number = ""
+
+        # Collect distinct non-empty units, sorted
+        units = sorted(set(
+            str(u).strip()
+            for u in group["unit"]
+            if pd.notna(u) and str(u).strip()
+        ))
+
+        results.append({
+            "borough": int(borough),
+            "block": int(block),
+            "lot": int(lot),
+            "streetnumber": canonical_number,
+            "streetname": canonical_name,
+            "unit_count": len(units),
+            "units": "; ".join(units) if units else "",
+        })
+
+    result_df = pd.DataFrame(results)
+    print(f"Normalized to {len(result_df):,} unique properties.")
+    return result_df
+
+
+CREATE_TABLE = """
+    DROP TABLE IF EXISTS normalized_addresses;
+    CREATE TABLE normalized_addresses (
+        id INT AUTO_INCREMENT PRIMARY KEY,
+        borough TINYINT NOT NULL,
+        block INT NOT NULL,
+        lot INT NOT NULL,
+        streetnumber VARCHAR(20) NOT NULL DEFAULT '',
+        streetname VARCHAR(100) NOT NULL DEFAULT '',
+        unit_count INT NOT NULL DEFAULT 0,
+        units TEXT,
+        UNIQUE KEY bbl (borough, block, lot),
+        INDEX idx_street (streetname, streetnumber),
+        INDEX idx_street_full (streetnumber, streetname, borough)
+    ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+"""
+
+INSERT_BATCH = """
+    INSERT INTO normalized_addresses
+        (borough, block, lot, streetnumber, streetname, unit_count, units)
+    VALUES (%s, %s, %s, %s, %s, %s, %s)
+"""
+
+BATCH_SIZE = 5000
+
+
+def write_to_db(df: pd.DataFrame):
+    """Write normalized addresses to the normalized_addresses table."""
+    conn = mysql.connector.connect(**DB_CONFIG)
+    cursor = conn.cursor()
+
+    print("Creating normalized_addresses table...")
+    for stmt in CREATE_TABLE.strip().split(";"):
+        stmt = stmt.strip()
+        if stmt:
+            cursor.execute(stmt)
+    conn.commit()
+
+    print(f"Inserting {len(df):,} rows...")
+    rows = list(df.itertuples(index=False, name=None))
+    for i in range(0, len(rows), BATCH_SIZE):
+        batch = rows[i : i + BATCH_SIZE]
+        cursor.executemany(INSERT_BATCH, batch)
+        conn.commit()
+        if (i // BATCH_SIZE) % 20 == 0:
+            print(f"  {i + len(batch):,} / {len(rows):,}")
+
+    print(f"Inserted {len(rows):,} rows.")
+    cursor.close()
+    conn.close()
+
+
+def main():
+    df = fetch_data()
+    normalized = build_normalized_addresses(df)
+
+    # Drop rows with no resolved address
+    normalized = normalized[normalized["streetname"] != ""]
+    normalized = normalized[normalized["streetnumber"] != ""]
+
+    # Ensure column order matches INSERT statement
+    normalized = normalized[
+        ["borough", "block", "lot", "streetnumber", "streetname", "unit_count", "units"]
+    ]
+
+    write_to_db(normalized)
+
+    # Print stats
+    borough_names = {1: "Manhattan", 2: "Bronx", 3: "Brooklyn", 4: "Queens", 5: "Staten Island"}
+    print(f"\nProperties by borough:")
+    for borough, count in normalized.groupby("borough").size().items():
+        print(f"  {borough_names.get(borough, borough)}: {count:,}")
+
+
+if __name__ == "__main__":
+    main()

--- a/mysql.dockerfile
+++ b/mysql.dockerfile
@@ -1,11 +1,9 @@
 FROM mysql:8.0
 
-RUN apt update \
- && apt update \
- && apt install -y \
+RUN microdnf install -y \
     curl \
     make \
- && rm -rf /var/lib/apt/lists/*
+ && microdnf clean all
 
 WORKDIR app
 


### PR DESCRIPTION
## Summary
- Replace `apt` with `microdnf` in `mysql.dockerfile` since `mysql:8.0` is based on Oracle Linux, not Debian/Ubuntu
- Remove redundant duplicate `apt update` call
- Fix the cache cleanup command to use `microdnf clean all`

## Test plan
- [x] Run `docker compose -f docker-compose.mysql.yml up` and verify the image builds successfully
- [x] Verify `curl` and `make` are available in the built container

🤖 Generated with [Claude Code](https://claude.com/claude-code)