### PR TITLE
Fix mysql.dockerfile: use microdnf instead of apt

### DIFF
--- a/mysql.dockerfile
+++ b/mysql.dockerfile
@@ -1,11 +1,9 @@
 FROM mysql:8.0
 
-RUN apt update \
- && apt update \
- && apt install -y \
+RUN microdnf install -y \
     curl \
     make \
- && rm -rf /var/lib/apt/lists/*
+ && microdnf clean all
 
 WORKDIR app
 


### PR DESCRIPTION
mysql:8.0 is based on Oracle Linux, not Debian/Ubuntu, so apt is not available. Replace apt with microdnf which is the package manager included in the image.